### PR TITLE
Improve touch input handling and wall collision guards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -171,6 +171,7 @@ canvas {
   margin-right: 25%;
   top: 40%;
   z-index: 2;
+  pointer-events: none;
 }
 
 .text-overlay-content {

--- a/src/App.js
+++ b/src/App.js
@@ -29,14 +29,16 @@ class App extends React.Component {
     }
 
     // moving logic
+    let effectiveDirection = this.props.player.direction;
     if(canChangeDirection(this.props.player, this.props.player.nextDirection, walls, timeElapsed)) {
       this.props.changeToNextDirection();
+      effectiveDirection = this.props.player.nextDirection;
     }
-    const nextPosition = this.props.player.direction
-      ? getNextCharacterPositionForDirection(this.props.player, this.props.player.direction, timeElapsed)
+    const nextPosition = effectiveDirection
+      ? getNextCharacterPositionForDirection(this.props.player, effectiveDirection, timeElapsed)
       : this.props.player.position;
     if(
-      this.props.player.direction &&
+      effectiveDirection &&
       hasWallCollision({ position: nextPosition, size: this.props.player.size }, walls)
     ) {
       this.props.playerCollided(0, this.props.player.position);

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import { resetGame, startGame, increaseScore, levelCompleted, powerModeStarted, 
 import { directionPressed, movePlayer, resetPlayer, playerCollided, changeToNextDirection, resetPlayerAnimation } from './actions/playerActions';
 import { coinCollected, pillCollected, resetLeveLProgress } from './actions/levelActions';
 import { hasWallCollision, findCollidingCoin, findCollidingPill } from './helpers/collisionHelpers';
-import { canChangeDirection } from './helpers/movementHelpers';
+import { canChangeDirection, getNextCharacterPositionForDirection } from './helpers/movementHelpers';
 
 import GameInfo from './components/GameInfo';
 import GameBoard from './components/GameBoard';
@@ -32,9 +32,19 @@ class App extends React.Component {
     if(canChangeDirection(this.props.player, this.props.player.nextDirection, walls, timeElapsed)) {
       this.props.changeToNextDirection();
     }
-    this.props.movePlayer(timeElapsed);
-    if(hasWallCollision(this.props.player, walls)) {
-      this.props.playerCollided(timeElapsed);
+    const nextPosition = this.props.player.direction
+      ? getNextCharacterPositionForDirection(this.props.player, this.props.player.direction, timeElapsed)
+      : this.props.player.position;
+    if(
+      this.props.player.direction &&
+      hasWallCollision({ position: nextPosition, size: this.props.player.size }, walls)
+    ) {
+      this.props.playerCollided(0, this.props.player.position);
+    } else {
+      this.props.movePlayer(timeElapsed);
+      if(hasWallCollision(this.props.player, walls)) {
+        this.props.playerCollided(timeElapsed);
+      }
     }
     const collidingCoin = findCollidingCoin(this.props.player, coins);
     const collidingPill = findCollidingPill(this.props.player, pills);
@@ -115,6 +125,9 @@ class App extends React.Component {
   }
 
   handleSwipeStart = (event) => {
+    if(event.type === 'pointerdown' && event.pointerType === 'touch') {
+      return;
+    }
     if(event.cancelable) {
       event.preventDefault();
     }
@@ -126,6 +139,9 @@ class App extends React.Component {
   }
 
   handleSwipeEnd = (event) => {
+    if(event.type === 'pointerup' && event.pointerType === 'touch') {
+      return;
+    }
     if(event.cancelable) {
       event.preventDefault();
     }
@@ -148,6 +164,20 @@ class App extends React.Component {
 
   handleSwipeCancel = () => {
     this.swipeStart = null;
+  }
+
+  handlePointerMovePressed = (direction, event) => {
+    if(event && event.pointerType === 'touch') {
+      return;
+    }
+    this.onMovePressed(direction);
+  }
+
+  handlePointerResetPressed = (event) => {
+    if(event && event.pointerType === 'touch') {
+      return;
+    }
+    this.handleResetPressed();
   }
 
   handleResetPressed = () => {
@@ -190,31 +220,36 @@ class App extends React.Component {
               type="button"
               className="touch-zone touch-zone--up"
               aria-label="Move up"
-              onPointerDown={() => this.onMovePressed('UP')}
+              onPointerDown={(event) => this.handlePointerMovePressed('UP', event)}
+              onTouchStart={() => this.onMovePressed('UP')}
             />
             <button
               type="button"
               className="touch-zone touch-zone--down"
               aria-label="Move down"
-              onPointerDown={() => this.onMovePressed('DOWN')}
+              onPointerDown={(event) => this.handlePointerMovePressed('DOWN', event)}
+              onTouchStart={() => this.onMovePressed('DOWN')}
             />
             <button
               type="button"
               className="touch-zone touch-zone--left"
               aria-label="Move left"
-              onPointerDown={() => this.onMovePressed('LEFT')}
+              onPointerDown={(event) => this.handlePointerMovePressed('LEFT', event)}
+              onTouchStart={() => this.onMovePressed('LEFT')}
             />
             <button
               type="button"
               className="touch-zone touch-zone--right"
               aria-label="Move right"
-              onPointerDown={() => this.onMovePressed('RIGHT')}
+              onPointerDown={(event) => this.handlePointerMovePressed('RIGHT', event)}
+              onTouchStart={() => this.onMovePressed('RIGHT')}
             />
             <button
               type="button"
               className="touch-reset"
               aria-label="Reset game"
-              onPointerDown={this.handleResetPressed}
+              onPointerDown={this.handlePointerResetPressed}
+              onTouchStart={this.handleResetPressed}
             >
               Reset
             </button>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -4,6 +4,8 @@ import { Provider } from 'react-redux';
 import App from './App';
 import configureStore from './store';
 
+const AppComponent = App.WrappedComponent || App;
+
 test('renders the Hac-Man header', () => {
   const store = configureStore();
   const { getAllByText } = render(
@@ -44,4 +46,49 @@ test('swipe controls update movement direction', () => {
     changedTouches: [{ clientX: 90, clientY: 10 }],
   });
   expect(store.getState().player.direction).toBe('RIGHT');
+});
+
+test('runGame uses accepted nextDirection for collision pre-check', () => {
+  const props = {
+    player: {
+      position: { x: 50, y: 50 },
+      size: 10,
+      speed: 10,
+      direction: 'RIGHT',
+      nextDirection: 'UP',
+    },
+    gameInfo: {
+      poweredUp: false,
+      powerModeEndsAt: null,
+      gameStarted: false,
+      showGameOver: false,
+      levelCompleted: false,
+      playingIntro: false,
+    },
+    levels: {
+      currentLevel: {
+        walls: [[55, 45, 10, 10]],
+        coins: [],
+        pills: [],
+      },
+    },
+    powerModeEnded: jest.fn(),
+    changeToNextDirection: jest.fn(),
+    movePlayer: jest.fn(),
+    playerCollided: jest.fn(),
+    pillCollected: jest.fn(),
+    coinCollected: jest.fn(),
+    increaseScore: jest.fn(),
+    powerModeStarted: jest.fn(),
+    levelCompleted: jest.fn(),
+    resetPlayerAnimation: jest.fn(),
+  };
+
+  const app = new AppComponent(props);
+  app.frameStart = 0;
+  app.runGame(1000);
+
+  expect(props.changeToNextDirection).toHaveBeenCalled();
+  expect(props.playerCollided).not.toHaveBeenCalled();
+  expect(props.movePlayer).toHaveBeenCalledWith(1);
 });

--- a/src/actions/playerActions.js
+++ b/src/actions/playerActions.js
@@ -18,10 +18,11 @@ export const movePlayer = (timeElapsed) => {
     };
 };
 
-export const playerCollided = (timeElapsed) => {
+export const playerCollided = (timeElapsed, position) => {
     return {
         type: 'COLLIDED',
         timeElapsed,
+        position,
     };
 };
 

--- a/src/reducers/playerReducer.js
+++ b/src/reducers/playerReducer.js
@@ -63,7 +63,9 @@ const playerReducer = (state = Object.assign({}, defaultState), action) => {
         case 'COLLIDED':
             // move the player back to their previous position and stop them moving
             return Object.assign({}, state, {
-                position: getNextCharacterPositionForDirection(state, state.direction, -action.timeElapsed),
+                position: action.position
+                    ? action.position
+                    : getNextCharacterPositionForDirection(state, state.direction, -action.timeElapsed),
                 direction: null
             });
         case 'RESET_PLAYER':


### PR DESCRIPTION
### Motivation

- Prevent the player from entering walls when a movement starts and avoid getting stuck in place by adding a pre-move collision guard. 
- Make mobile touch controls reliable and avoid double-triggering by pointer + touch events. 
- Ensure the intro/splash text does not intercept taps on mobile devices.

### Description

- Add a pre-move collision check using `getNextCharacterPositionForDirection` in `src/App.js` and stop movement if the next step would collide with walls. 
- Update the `playerCollided` action to accept an optional `position` argument in `src/actions/playerActions.js` and use it in the reducer so collisions can place the player at the last safe position in `src/reducers/playerReducer.js`. 
- Modify touch/pointer handling in `src/App.js` to: ignore pointer events coming from touch inputs to avoid duplicate firing; add explicit `onTouchStart` for touch-only activation on the directional and reset buttons; and keep pointer/swipe support for non-touch devices. 
- Prevent the splash/stage text overlay from blocking inputs by setting `pointer-events: none` on `.text-overlay` in `src/App.css`.

### Testing

- Launched the dev server and used a Playwright script to visit the app and capture a screenshot, which completed and produced an artifact. 
- Attempted to run the development server build flow which ultimately failed to compile due to `Module not found: Can't resolve 'react-dom/client'` in `src/index.js`, causing the local compile to fail. 
- No unit test suite was executed as part of this change set in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988b1d5548c832fa9ed1ca1ae21abd7)