### PR TITLE
Refine rail-based movement and collision

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import { resetGame, startGame, increaseScore, levelCompleted, powerModeStarted, 
 import { directionPressed, movePlayer, resetPlayer, playerCollided, changeToNextDirection, resetPlayerAnimation } from './actions/playerActions';
 import { coinCollected, pillCollected, resetLeveLProgress } from './actions/levelActions';
 import { findCollidingCoin, findCollidingPill } from './helpers/collisionHelpers';
-import { canChangeDirection, getNextCharacterRailPosition } from './helpers/movementHelpers';
+import { canChangeDirection, checkAndTransformIntoBounds, getNextCharacterRailPosition } from './helpers/movementHelpers';
 
 import GameInfo from './components/GameInfo';
 import GameBoard from './components/GameBoard';
@@ -38,14 +38,17 @@ class App extends React.Component {
       ? getNextCharacterRailPosition(this.props.player, effectiveDirection, timeElapsed, walls)
       : { position: this.props.player.position, blocked: false };
 
+    const wrappedPosition = Object.assign({}, nextMove.position);
+    checkAndTransformIntoBounds(wrappedPosition);
+
     if(nextMove.blocked) {
-      this.props.playerCollided(0, nextMove.position);
+      this.props.playerCollided(0, wrappedPosition);
     } else {
-      this.props.movePlayer(timeElapsed, nextMove.position);
+      this.props.movePlayer(timeElapsed, wrappedPosition);
     }
 
     const playerForCollision = Object.assign({}, this.props.player, {
-      position: nextMove.position,
+      position: wrappedPosition,
     });
     const collidingCoin = findCollidingCoin(playerForCollision, coins);
     const collidingPill = findCollidingPill(playerForCollision, pills);

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -90,5 +90,5 @@ test('runGame uses accepted nextDirection for collision pre-check', () => {
 
   expect(props.changeToNextDirection).toHaveBeenCalled();
   expect(props.playerCollided).not.toHaveBeenCalled();
-  expect(props.movePlayer).toHaveBeenCalledWith(1);
+  expect(props.movePlayer).toHaveBeenCalledWith(1, { x: 42, y: 40 });
 });

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -92,3 +92,47 @@ test('runGame uses accepted nextDirection for collision pre-check', () => {
   expect(props.playerCollided).not.toHaveBeenCalled();
   expect(props.movePlayer).toHaveBeenCalledWith(1, { x: 42, y: 40 });
 });
+
+test('runGame wraps positions before checking coin collisions', () => {
+  const props = {
+    player: {
+      position: { x: 810, y: 14 },
+      size: 10,
+      speed: 10,
+      direction: 'RIGHT',
+      nextDirection: null,
+    },
+    gameInfo: {
+      poweredUp: false,
+      powerModeEndsAt: null,
+      gameStarted: false,
+      showGameOver: false,
+      levelCompleted: false,
+      playingIntro: false,
+    },
+    levels: {
+      currentLevel: {
+        walls: [],
+        coins: [[8, 14]],
+        pills: [],
+      },
+    },
+    powerModeEnded: jest.fn(),
+    changeToNextDirection: jest.fn(),
+    movePlayer: jest.fn(),
+    playerCollided: jest.fn(),
+    pillCollected: jest.fn(),
+    coinCollected: jest.fn(),
+    increaseScore: jest.fn(),
+    powerModeStarted: jest.fn(),
+    levelCompleted: jest.fn(),
+    resetPlayerAnimation: jest.fn(),
+  };
+
+  const app = new AppComponent(props);
+  app.frameStart = 0;
+  app.runGame(1000);
+
+  expect(props.coinCollected).toHaveBeenCalled();
+  expect(props.increaseScore).toHaveBeenCalledWith(10);
+});

--- a/src/actions/playerActions.js
+++ b/src/actions/playerActions.js
@@ -11,10 +11,11 @@ export const changeToNextDirection = () => {
     };
 };
 
-export const movePlayer = (timeElapsed) => {
+export const movePlayer = (timeElapsed, position) => {
     return {
         type: 'MOVE',
         timeElapsed,
+        position,
     };
 };
 

--- a/src/helpers/__tests__/movementHelpers.test.js
+++ b/src/helpers/__tests__/movementHelpers.test.js
@@ -1,4 +1,9 @@
-import { canChangeDirection, checkAndTransformIntoBounds, getNextCharacterPositionForDirection } from '../movementHelpers';
+import {
+  canChangeDirection,
+  checkAndTransformIntoBounds,
+  getNextCharacterPositionForDirection,
+  getNextCharacterRailPosition,
+} from '../movementHelpers';
 
 describe('movementHelpers', () => {
   it('calculates the next position for each direction', () => {
@@ -7,10 +12,37 @@ describe('movementHelpers', () => {
       speed: 5,
     };
 
-    expect(getNextCharacterPositionForDirection(character, 'UP', 1)).toEqual({ x: 10, y: 5 });
-    expect(getNextCharacterPositionForDirection(character, 'DOWN', 1)).toEqual({ x: 10, y: 15 });
-    expect(getNextCharacterPositionForDirection(character, 'LEFT', 2)).toEqual({ x: 0, y: 10 });
-    expect(getNextCharacterPositionForDirection(character, 'RIGHT', 2)).toEqual({ x: 20, y: 10 });
+    expect(getNextCharacterPositionForDirection(character, 'UP', 1)).toEqual({ x: 14, y: 5 });
+    expect(getNextCharacterPositionForDirection(character, 'DOWN', 1)).toEqual({ x: 14, y: 15 });
+    expect(getNextCharacterPositionForDirection(character, 'LEFT', 2)).toEqual({ x: 0, y: 14 });
+    expect(getNextCharacterPositionForDirection(character, 'RIGHT', 2)).toEqual({ x: 20, y: 14 });
+  });
+
+  it('moves along rails without crossing into blocked tiles', () => {
+    const character = {
+      position: { x: 14, y: 14 },
+      speed: 28,
+    };
+    const walls = [
+      [28, 0, 28, 28],
+    ];
+
+    const result = getNextCharacterRailPosition(character, 'RIGHT', 1, walls);
+
+    expect(result.position).toEqual({ x: 28, y: 14 });
+    expect(result.blocked).toBe(true);
+  });
+
+  it('moves across multiple tiles when clear', () => {
+    const character = {
+      position: { x: 14, y: 14 },
+      speed: 56,
+    };
+
+    const result = getNextCharacterRailPosition(character, 'RIGHT', 1, []);
+
+    expect(result.position).toEqual({ x: 70, y: 14 });
+    expect(result.blocked).toBe(false);
   });
 
   it('wraps positions that move beyond the board bounds', () => {
@@ -23,7 +55,7 @@ describe('movementHelpers', () => {
 
   it('returns false when there is no next direction', () => {
     const character = {
-      position: { x: 5, y: 5 },
+      position: { x: 14, y: 14 },
       speed: 10,
       size: 2,
     };
@@ -34,25 +66,36 @@ describe('movementHelpers', () => {
 
   it('prevents direction changes when a wall blocks the next move', () => {
     const character = {
-      position: { x: 5, y: 5 },
+      position: { x: 14, y: 14 },
       speed: 10,
       size: 2,
     };
     const walls = [
-      [4, 0, 4, 10],
+      [28, 0, 28, 28],
     ];
+
+    expect(canChangeDirection(character, 'RIGHT', walls, 0.1)).toBe(false);
+  });
+
+  it('prevents direction changes when not aligned to a rail', () => {
+    const character = {
+      position: { x: 14, y: 3 },
+      speed: 10,
+      size: 2,
+    };
+    const walls = [];
 
     expect(canChangeDirection(character, 'RIGHT', walls, 0.1)).toBe(false);
   });
 
   it('allows direction changes when the next move is clear', () => {
     const character = {
-      position: { x: 5, y: 5 },
+      position: { x: 14, y: 14 },
       speed: 10,
       size: 2,
     };
     const walls = [
-      [10, 0, 4, 10],
+      [56, 0, 28, 28],
     ];
 
     expect(canChangeDirection(character, 'RIGHT', walls, 0.1)).toBe(true);

--- a/src/helpers/__tests__/movementHelpers.test.js
+++ b/src/helpers/__tests__/movementHelpers.test.js
@@ -45,6 +45,18 @@ describe('movementHelpers', () => {
     expect(result.blocked).toBe(false);
   });
 
+  it('advances past a boundary without stalling when the next tile is open', () => {
+    const character = {
+      position: { x: 28, y: 14 },
+      speed: 28,
+    };
+
+    const result = getNextCharacterRailPosition(character, 'RIGHT', 1, []);
+
+    expect(result.position.x).toBeGreaterThan(28);
+    expect(result.blocked).toBe(false);
+  });
+
   it('wraps positions that move beyond the board bounds', () => {
     const position = { x: 820, y: -5 };
     checkAndTransformIntoBounds(position);

--- a/src/helpers/__tests__/movementHelpers.test.js
+++ b/src/helpers/__tests__/movementHelpers.test.js
@@ -57,6 +57,21 @@ describe('movementHelpers', () => {
     expect(result.blocked).toBe(false);
   });
 
+  it('stops at a boundary when the next tile is blocked', () => {
+    const character = {
+      position: { x: 28, y: 14 },
+      speed: 28,
+    };
+    const walls = [
+      [28, 0, 28, 28],
+    ];
+
+    const result = getNextCharacterRailPosition(character, 'RIGHT', 1, walls);
+
+    expect(result.position).toEqual({ x: 28, y: 14 });
+    expect(result.blocked).toBe(true);
+  });
+
   it('wraps positions that move beyond the board bounds', () => {
     const position = { x: 820, y: -5 };
     checkAndTransformIntoBounds(position);

--- a/src/helpers/movementHelpers.js
+++ b/src/helpers/movementHelpers.js
@@ -1,6 +1,127 @@
-import { hasWallCollision } from "./collisionHelpers";
-
 const boardSize = 812;
+const tileSize = 28;
+const railCenterOffset = tileSize / 2;
+const railSnapThreshold = tileSize * 0.3;
+const tileIndexEpsilon = 1e-6;
+const blockedTilesCache = new WeakMap();
+
+const getClosestRailCoord = (coord) =>
+    Math.round((coord - railCenterOffset) / tileSize) * tileSize + railCenterOffset;
+
+const getTileCenter = (tileIndex) => tileIndex * tileSize + railCenterOffset;
+
+const getTileIndexForDirection = (coord, direction) => {
+    if(direction === 'LEFT' || direction === 'UP') {
+        return Math.floor((coord + tileIndexEpsilon) / tileSize);
+    }
+    if(direction === 'RIGHT' || direction === 'DOWN') {
+        return Math.floor((coord - tileIndexEpsilon) / tileSize);
+    }
+    return Math.round((coord - railCenterOffset) / tileSize);
+};
+
+const buildBlockedTiles = (walls) => {
+    if(blockedTilesCache.has(walls)) {
+        return blockedTilesCache.get(walls);
+    }
+
+    const blockedTiles = new Set();
+    for (const wall of walls) {
+        const startX = Math.floor(wall[0] / tileSize);
+        const endX = Math.ceil((wall[0] + wall[2]) / tileSize) - 1;
+        const startY = Math.floor(wall[1] / tileSize);
+        const endY = Math.ceil((wall[1] + wall[3]) / tileSize) - 1;
+
+        for (let x = startX; x <= endX; x += 1) {
+            for (let y = startY; y <= endY; y += 1) {
+                blockedTiles.add(`${x},${y}`);
+            }
+        }
+    }
+
+    blockedTilesCache.set(walls, blockedTiles);
+    return blockedTiles;
+};
+
+const isTileBlocked = (tileX, tileY, walls) => {
+    const blockedTiles = buildBlockedTiles(walls);
+    return blockedTiles.has(`${tileX},${tileY}`);
+};
+
+const alignPositionToRail = (position, direction) => {
+    const aligned = Object.assign({}, position);
+    if(direction === 'LEFT' || direction === 'RIGHT') {
+        aligned.y = getClosestRailCoord(position.y);
+    } else if(direction === 'UP' || direction === 'DOWN') {
+        aligned.x = getClosestRailCoord(position.x);
+    }
+    return aligned;
+};
+
+const getDistanceFromRail = (position, direction) => {
+    if(direction === 'LEFT' || direction === 'RIGHT') {
+        return Math.abs(position.y - getClosestRailCoord(position.y));
+    }
+    if(direction === 'UP' || direction === 'DOWN') {
+        return Math.abs(position.x - getClosestRailCoord(position.x));
+    }
+    return Infinity;
+};
+
+const getRailMoveResult = (character, direction, duration, walls) => {
+    const { position, speed } = character;
+    if(!direction || duration === 0) {
+        return { position: Object.assign({}, position), blocked: false };
+    }
+
+    const moveAmount = Math.max(0, speed * duration);
+    const alignedPosition = alignPositionToRail(position, direction);
+    let coord = direction === 'LEFT' || direction === 'RIGHT' ? alignedPosition.x : alignedPosition.y;
+    const fixedCoord = direction === 'LEFT' || direction === 'RIGHT'
+        ? alignedPosition.y
+        : alignedPosition.x;
+    const fixedTileIndex = getTileIndexForDirection(fixedCoord, direction);
+    const step = direction === 'LEFT' || direction === 'UP' ? -1 : 1;
+
+    let remaining = moveAmount;
+    let blocked = false;
+
+    while(remaining > 0) {
+        const tileIndex = getTileIndexForDirection(coord, direction);
+        const tileCenter = getTileCenter(tileIndex);
+        const boundary = tileCenter + step * (tileSize / 2);
+        const distanceToBoundary = step > 0 ? boundary - coord : coord - boundary;
+
+        if(distanceToBoundary >= remaining) {
+            coord += step * remaining;
+            remaining = 0;
+            break;
+        }
+
+        coord = boundary;
+        remaining -= distanceToBoundary;
+
+        const nextTileIndex = tileIndex + step;
+        const nextTileBlocked = direction === 'LEFT' || direction === 'RIGHT'
+            ? isTileBlocked(nextTileIndex, fixedTileIndex, walls)
+            : isTileBlocked(fixedTileIndex, nextTileIndex, walls);
+
+        if(nextTileBlocked) {
+            blocked = true;
+            remaining = 0;
+            break;
+        }
+    }
+
+    const nextPosition = Object.assign({}, alignedPosition);
+    if(direction === 'LEFT' || direction === 'RIGHT') {
+        nextPosition.x = coord;
+    } else {
+        nextPosition.y = coord;
+    }
+
+    return { position: nextPosition, blocked };
+};
 
 /**
  * Generates the next position for a character along a certain direction given a time interval
@@ -9,28 +130,11 @@ const boardSize = 812;
  * @param {*} duration the duration of the movement
  */
 export function getNextCharacterPositionForDirection (character, direction, duration) {
-    const { position, speed } = character;
-    const moveAmount = speed * duration;
-    const newPosition = Object.assign({}, position);
+    return getRailMoveResult(character, direction, duration, []).position;
+}
 
-    switch(direction) {
-        case 'UP':
-            newPosition.y -= moveAmount;
-            break;
-        case 'DOWN':
-            newPosition.y += moveAmount;
-            break;
-        case 'LEFT':
-            newPosition.x -= moveAmount;
-            break;
-        case 'RIGHT':
-            newPosition.x += moveAmount;
-            break;
-        default:
-            // default is not to move
-    }
-
-    return newPosition;
+export function getNextCharacterRailPosition(character, direction, duration, walls) {
+    return getRailMoveResult(character, direction, duration, walls);
 }
 
 /**
@@ -63,9 +167,25 @@ export function canChangeDirection(character, nextDirection, walls, duration) {
         return false;
     }
 
-    const nextCords = getNextCharacterPositionForDirection(character, nextDirection, duration);
-    if(hasWallCollision({ position: nextCords, size: character.size}, walls)) {
+    if(getDistanceFromRail(character.position, nextDirection) > railSnapThreshold) {
         return false;
     }
-    return true;
+
+    const alignedPosition = alignPositionToRail(character.position, nextDirection);
+    const movingCoord = nextDirection === 'LEFT' || nextDirection === 'RIGHT'
+        ? alignedPosition.x
+        : alignedPosition.y;
+    const fixedCoord = nextDirection === 'LEFT' || nextDirection === 'RIGHT'
+        ? alignedPosition.y
+        : alignedPosition.x;
+    const movingTileIndex = getTileIndexForDirection(movingCoord, nextDirection);
+    const fixedTileIndex = getTileIndexForDirection(fixedCoord, nextDirection);
+    const step = nextDirection === 'LEFT' || nextDirection === 'UP' ? -1 : 1;
+    const nextTileIndex = movingTileIndex + step;
+
+    const nextTileBlocked = nextDirection === 'LEFT' || nextDirection === 'RIGHT'
+        ? isTileBlocked(nextTileIndex, fixedTileIndex, walls)
+        : isTileBlocked(fixedTileIndex, nextTileIndex, walls);
+
+    return !nextTileBlocked;
 }

--- a/src/helpers/movementHelpers.js
+++ b/src/helpers/movementHelpers.js
@@ -92,6 +92,12 @@ const getRailMoveResult = (character, direction, duration, walls) => {
         const boundary = tileCenter + step * (tileSize / 2);
         const distanceToBoundary = step > 0 ? boundary - coord : coord - boundary;
 
+        if(distanceToBoundary === 0) {
+            coord += step * tileIndexEpsilon;
+            remaining = Math.max(0, remaining - tileIndexEpsilon);
+            continue;
+        }
+
         if(distanceToBoundary >= remaining) {
             coord += step * remaining;
             remaining = 0;

--- a/src/helpers/movementHelpers.js
+++ b/src/helpers/movementHelpers.js
@@ -93,6 +93,17 @@ const getRailMoveResult = (character, direction, duration, walls) => {
         const distanceToBoundary = step > 0 ? boundary - coord : coord - boundary;
 
         if(distanceToBoundary === 0) {
+            const nextTileIndex = tileIndex + step;
+            const nextTileBlocked = direction === 'LEFT' || direction === 'RIGHT'
+                ? isTileBlocked(nextTileIndex, fixedTileIndex, walls)
+                : isTileBlocked(fixedTileIndex, nextTileIndex, walls);
+
+            if(nextTileBlocked) {
+                blocked = true;
+                remaining = 0;
+                break;
+            }
+
             coord += step * tileIndexEpsilon;
             remaining = Math.max(0, remaining - tileIndexEpsilon);
             continue;

--- a/src/reducers/__tests__/playerReducer.test.js
+++ b/src/reducers/__tests__/playerReducer.test.js
@@ -22,23 +22,25 @@ describe('playerReducer', () => {
 
   it('moves the player and advances animation frame', () => {
     const state = playerReducer(undefined, { type: 'DIRECTION_PRESSED', direction: 'RIGHT' });
-    const moved = playerReducer(state, { type: 'MOVE', timeElapsed: 1 });
+    const nextPosition = { x: state.position.x + 10, y: state.position.y };
+    const moved = playerReducer(state, { type: 'MOVE', timeElapsed: 1, position: nextPosition });
 
-    expect(moved.position.x).toBeGreaterThan(state.position.x);
+    expect(moved.position).toEqual(nextPosition);
     expect(moved.animationFrameCount).toBe(state.animationFrameCount + 1);
   });
 
   it('moves the player back when collided and clears direction', () => {
     const state = playerReducer(undefined, { type: 'DIRECTION_PRESSED', direction: 'RIGHT' });
-    const moved = playerReducer(state, { type: 'MOVE', timeElapsed: 1 });
-    const collided = playerReducer(moved, { type: 'COLLIDED', timeElapsed: 1 });
+    const nextPosition = { x: state.position.x + 10, y: state.position.y };
+    const moved = playerReducer(state, { type: 'MOVE', timeElapsed: 1, position: nextPosition });
+    const collided = playerReducer(moved, { type: 'COLLIDED', timeElapsed: 1, position: state.position });
 
     expect(collided.direction).toBeNull();
-    expect(collided.position.x).toBeLessThan(moved.position.x);
+    expect(collided.position).toEqual(state.position);
   });
 
   it('resets player state', () => {
-    const moved = playerReducer(undefined, { type: 'MOVE', timeElapsed: 1 });
+    const moved = playerReducer(undefined, { type: 'MOVE', timeElapsed: 1, position: { x: 10, y: 10 } });
     const reset = playerReducer(moved, { type: 'RESET_PLAYER' });
     const defaultState = playerReducer(undefined, { type: '@@INIT' });
 
@@ -47,7 +49,7 @@ describe('playerReducer', () => {
 
   it('resets the player animation sprite', () => {
     const state = playerReducer(undefined, { type: 'DIRECTION_PRESSED', direction: 'RIGHT' });
-    const moved = playerReducer(state, { type: 'MOVE', timeElapsed: 1 });
+    const moved = playerReducer(state, { type: 'MOVE', timeElapsed: 1, position: { x: 10, y: 10 } });
     const resetAnimation = playerReducer(moved, { type: 'RESET_PLAYER_ANIMATION' });
     const defaultState = playerReducer(undefined, { type: '@@INIT' });
 

--- a/src/reducers/playerReducer.js
+++ b/src/reducers/playerReducer.js
@@ -52,7 +52,9 @@ const playerReducer = (state = Object.assign({}, defaultState), action) => {
                 nextDirection: null
             });
         case 'MOVE':
-            let newPosition = getNextCharacterPositionForDirection(state, state.direction, action.timeElapsed);
+            let newPosition = action.position
+                ? Object.assign({}, action.position)
+                : getNextCharacterPositionForDirection(state, state.direction, action.timeElapsed);
             checkAndTransformIntoBounds(newPosition);
             
             return Object.assign({}, state, {


### PR DESCRIPTION
### Motivation
- Prevent characters from drifting off tile rails by advancing movement tile-by-tile and treating tiles as the unit of collision.
- Replace ad-hoc bounding-box prechecks with deterministic tile-occupancy checks so direction changes and movement stop exactly at blocked tile boundaries.
- Centralize rail alignment, snapping thresholds, and tile-index math to make behavior predictable and testable.

### Description
- Reworked `src/helpers/movementHelpers.js` to add tile utilities (`getTileCenter`, `getTileIndexForDirection`), blocked-tile caching (`buildBlockedTiles` / `isTileBlocked`), and a core `getRailMoveResult` that advances along rails and returns `{ position, blocked }`.
- Added `getNextCharacterRailPosition` (returns move + blocked flag) and made `getNextCharacterPositionForDirection` delegate to the rail mover for consistency; updated `canChangeDirection` to use tile occupancy checks and rail-alignment threshold.
- Updated game loop in `src/App.js` to consume rail move results, pass the projected `position` into `movePlayer` and use the projected position for coin/pill collision checks, and to dispatch `playerCollided` when the rail move is blocked.
- Changed the `movePlayer` and `playerCollided` action signatures in `src/actions/playerActions.js` to accept an explicit `position`, and updated `src/reducers/playerReducer.js` to use `action.position` when present (including collision rollback behavior).
- Expanded and adjusted tests in `src/helpers/__tests__/movementHelpers.test.js`, `src/reducers/__tests__/playerReducer.test.js`, and `src/App.test.js` to cover rail alignment, blocked tiles, multi-tile moves, and the new move payload shape.

### Testing
- Ran the test suite with `yarn test --watchAll=false`, which completed successfully; individual test files that passed include `playerReducer.test.js`, `App.test.js`, `gameInfoReducer.test.js`, `collisionHelpers.test.js`, `levelReducer.test.js`, and `animationHelpers.test.js`.
- No automated test failures were observed. (A local `yarn start` attempt hit an unrelated dev-server compile error: "Can't resolve 'react-dom/client'", which does not affect the unit test results.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988be455818832f85f1f596b89ac52e)